### PR TITLE
Added initialization code for IdentityServer in Startup.

### DIFF
--- a/source/Host/Config/Factory.cs
+++ b/source/Host/Config/Factory.cs
@@ -30,12 +30,18 @@ namespace Host.Config
                 ConnectionString = connString,
             };
             var factory = new IdentityServerServiceFactory();
-            //Clients
+
+            // Clients
             ConfigureClients(Clients.Get(), efConfig);
-            //scopes
+            
+            // Scopes
             ConfigureScopes(Scopes.Get(), efConfig);
+            
             factory.RegisterConfigurationServices(efConfig);
             factory.RegisterOperationalServices(efConfig);
+
+            factory.UseInMemoryUsers(Users.Get());
+
             return factory;
         }
 

--- a/source/Host/Config/Users.cs
+++ b/source/Host/Config/Users.cs
@@ -1,0 +1,33 @@
+﻿using System.Collections.Generic;
+using System.Security.Claims;
+using IdentityServer3.Core;
+using IdentityServer3.Core.Services.InMemory;
+
+namespace Host.Config
+{
+    static class Users
+    {
+        public static List<InMemoryUser> Get()
+        {
+            return new List<InMemoryUser>
+            {
+                new InMemoryUser{Subject = "alice", Username = "alice", Password = "alice", 
+                    Claims = new Claim[]
+                    {
+                        new Claim(Constants.ClaimTypes.GivenName, "Alice"),
+                        new Claim(Constants.ClaimTypes.FamilyName, "Smith"),
+                        new Claim(Constants.ClaimTypes.Email, "AliceSmith@email.com"),
+                    }
+                },
+                new InMemoryUser{Subject = "bob", Username = "bob", Password = "bob", 
+                    Claims = new Claim[]
+                    {
+                        new Claim(Constants.ClaimTypes.GivenName, "Bob"),
+                        new Claim(Constants.ClaimTypes.FamilyName, "Smith"),
+                        new Claim(Constants.ClaimTypes.Email, "BobSmith@email.com"),
+                    }
+                },
+            };
+        }
+    }
+}

--- a/source/Host/Host.csproj
+++ b/source/Host/Host.csproj
@@ -20,6 +20,8 @@
     <IISExpressWindowsAuthentication>disabled</IISExpressWindowsAuthentication>
     <IISExpressUseClassicPipelineMode>false</IISExpressUseClassicPipelineMode>
     <UseGlobalApplicationHostFile />
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -139,8 +141,10 @@
     <Reference Include="System.EnterpriseServices" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="Config\idsrv3test.pfx" />
-    <Content Include="packages.config" />
+    <EmbeddedResource Include="Config\idsrv3test.pfx" />
+    <Content Include="packages.config">
+      <SubType>Designer</SubType>
+    </Content>
     <None Include="Web.Debug.config">
       <DependentUpon>Web.config</DependentUpon>
     </None>
@@ -149,7 +153,9 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <Content Include="Web.config" />
+    <Content Include="Web.config">
+      <SubType>Designer</SubType>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Config\Certificate.cs" />
@@ -158,6 +164,7 @@
     <Compile Include="Config\IdentityAdminManagerService.cs" />
     <Compile Include="Config\IdentityAdminServiceExtensions.cs" />
     <Compile Include="Config\Scopes.cs" />
+    <Compile Include="Config\Users.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Startup.cs" />
   </ItemGroup>
@@ -188,6 +195,13 @@
       </FlavorProperties>
     </VisualStudio>
   </ProjectExtensions>
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/source/Host/Startup.cs
+++ b/source/Host/Startup.cs
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 using IdentityAdmin.Configuration;
+using IdentityServer3.Core.Configuration;
 using Owin;
 using Serilog;
 using WebHost.Config;
+using Host.Config;
 
 namespace Host
 {
@@ -28,6 +30,14 @@ namespace Host
                .MinimumLevel.Debug()
                .WriteTo.Trace()
                .CreateLogger();
+
+            var options = new IdentityServerOptions
+            {
+                SigningCertificate = Certificate.Get(),
+                Factory = Factory.Configure("IdSvr3ConfigAdmin")
+            };
+
+            app.UseIdentityServer(options);
 
             app.Map("/adm", adminApp =>
             {


### PR DESCRIPTION
I noticed that the **Host.Config.Factory.cs** code, which was intended to create clients & scopes if none were detected in the DB, was never traversed. I made modifications in the Startup class to use the IdentityServer configured with that Factory.

The following 2 changes were made to facilitate the IdentityServer code:
- Changed idsrv3test.pfx Build Action to Embedded Resource. 
- Added Users class (_copied from IdentityServer3.EntityFramework repo_) for generating dummy users.